### PR TITLE
week 9, 예약완료 정보 Kafka에 저장

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,16 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.redisson:redisson-spring-boot-starter:3.43.0")
 
+    // Kafka
+    implementation ("org.springframework.kafka:spring-kafka")
+    testImplementation ("org.springframework.kafka:spring-kafka-test")
+    testImplementation ("org.springframework.kafka:spring-kafka")
+    testImplementation ("org.testcontainers:kafka")
+
+    // Jackson
+    implementation ("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.0")
+    implementation ("com.fasterxml.jackson.core:jackson-databind")
+
     developmentOnly("org.springframework.boot:spring-boot-devtools")
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   mysql:
     image: mysql:8.0
@@ -9,8 +8,27 @@ services:
       - MYSQL_USER=application
       - MYSQL_PASSWORD=application
       - MYSQL_DATABASE=hhplus
-    volumes:
-      - ./data/mysql/:/var/lib/mysql
+
+
+  zookeeper:
+    image: 'confluentinc/cp-zookeeper:latest'
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - '2181:2181'
+
+  kafka:
+    image: 'confluentinc/cp-kafka:latest'
+    depends_on:
+      - zookeeper
+    ports:
+      - '9092:9092'
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
 
 networks:
   default:

--- a/src/main/java/kr/hhplus/be/server/api/reservation/application/event/listener/ReservationEventListener.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/application/event/listener/ReservationEventListener.java
@@ -1,0 +1,37 @@
+package kr.hhplus.be.server.api.reservation.application.event.listener;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.hhplus.be.server.api.reservation.application.event.ReservationConfirmedEvent;
+import kr.hhplus.be.server.api.reservation.application.service.MessageProducer;
+import kr.hhplus.be.server.api.reservation.domain.entity.ReservationOutbox;
+import kr.hhplus.be.server.api.reservation.domain.repository.ReservationOutboxRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class ReservationEventListener {
+
+    private final ReservationOutboxRepository reservationOutboxRepository;
+    private final MessageProducer messageProducer;
+    private final ObjectMapper objectMapper;
+
+    String topicName = "sending-reservation-request";
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void saveOutbox(ReservationConfirmedEvent event) {
+        ReservationOutbox outbox = new ReservationOutbox(topicName, event.reservationResult(), LocalDateTime.now(), objectMapper);
+        reservationOutboxRepository.save(outbox);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void sendReservationInfo(ReservationConfirmedEvent event) {
+        messageProducer.send(topicName, event.reservationResult());
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/reservation/application/service/MessageProducer.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/application/service/MessageProducer.java
@@ -1,0 +1,7 @@
+package kr.hhplus.be.server.api.reservation.application.service;
+
+import kr.hhplus.be.server.api.reservation.application.dto.ReservationResult;
+
+public interface MessageProducer {
+    void send(String topic, ReservationResult message);
+}

--- a/src/main/java/kr/hhplus/be/server/api/reservation/application/service/ReservationOutboxScheduler.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/application/service/ReservationOutboxScheduler.java
@@ -1,0 +1,38 @@
+package kr.hhplus.be.server.api.reservation.application.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.hhplus.be.server.api.reservation.application.dto.ReservationResult;
+import kr.hhplus.be.server.api.reservation.domain.repository.ReservationOutboxRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ReservationOutboxScheduler {
+
+    private final ReservationOutboxRepository outboxRepository;
+    private final MessageProducer messageProducer;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    @Scheduled(fixedRate = 5000)
+    public void processOutboxEvents() {
+        outboxRepository.findTop10ByPublishedFalseOrderByCreatedAtAsc().forEach(outbox -> {
+            if(outbox.getCreatedAt().isBefore(LocalDateTime.now().minusMinutes(5))) {
+                try {
+                    ReservationResult result = objectMapper.readValue(outbox.getPayload(), ReservationResult.class);
+                    messageProducer.send(outbox.getEventType(), result);
+                } catch (JsonProcessingException e) {
+                    log.error("Error Processing Outbox Event", e);
+                }
+            }
+        });
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/reservation/domain/entity/Reservation.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/domain/entity/Reservation.java
@@ -1,5 +1,9 @@
 package kr.hhplus.be.server.api.reservation.domain.entity;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -31,12 +35,16 @@ public class Reservation {
 
 	private int seatNo;
 
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
 	private LocalDate concertDate;
 
 	private BigDecimal finalPrice;
 
 	private Boolean isReserved = false;
 
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
 	@Column(nullable = false)
 	private LocalDateTime expiredAt;
 

--- a/src/main/java/kr/hhplus/be/server/api/reservation/domain/entity/ReservationOutbox.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/domain/entity/ReservationOutbox.java
@@ -1,0 +1,48 @@
+package kr.hhplus.be.server.api.reservation.domain.entity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import kr.hhplus.be.server.api.reservation.application.dto.ReservationResult;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Slf4j
+@NoArgsConstructor
+public class ReservationOutbox {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String eventType;
+    private String payload;
+    private LocalDateTime createdAt;
+    private boolean published;
+
+    public ReservationOutbox(String eventType, ReservationResult payload, LocalDateTime createdAt, ObjectMapper objectMapper) {
+        this.eventType = eventType;
+        this.payload = serializePayload(payload, objectMapper);
+        this.createdAt = createdAt;
+    }
+
+    public void published() {
+        this.published = true;
+    }
+
+    private String serializePayload(ReservationResult payload, ObjectMapper objectMapper) {
+        try {
+            return objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException e) {
+            log.error("Error Processing Outbox Event", e);
+            return null;
+        }
+    }
+
+}

--- a/src/main/java/kr/hhplus/be/server/api/reservation/domain/repository/ReservationOutboxRepository.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/domain/repository/ReservationOutboxRepository.java
@@ -1,0 +1,10 @@
+package kr.hhplus.be.server.api.reservation.domain.repository;
+
+import kr.hhplus.be.server.api.reservation.domain.entity.ReservationOutbox;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ReservationOutboxRepository extends JpaRepository<ReservationOutbox, Long> {
+    List<ReservationOutbox> findTop10ByPublishedFalseOrderByCreatedAtAsc();
+}

--- a/src/main/java/kr/hhplus/be/server/api/reservation/infrastructure/KafkaMessageProducer.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/infrastructure/KafkaMessageProducer.java
@@ -1,0 +1,18 @@
+package kr.hhplus.be.server.api.reservation.infrastructure;
+
+import kr.hhplus.be.server.api.reservation.application.dto.ReservationResult;
+import kr.hhplus.be.server.api.reservation.application.service.MessageProducer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class KafkaMessageProducer implements MessageProducer {
+    private final KafkaTemplate<String, ReservationResult> kafkaTemplate;
+
+    @Override
+    public void send(String topic, ReservationResult message) {
+            kafkaTemplate.send(topic, message);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/api/reservation/presentation/consumer/ReservationConsumer.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/presentation/consumer/ReservationConsumer.java
@@ -1,0 +1,39 @@
+package kr.hhplus.be.server.api.reservation.presentation.consumer;
+
+import kr.hhplus.be.server.api.reservation.application.dto.ReservationResult;
+import kr.hhplus.be.server.api.reservation.application.event.ReservationConfirmedEvent;
+import kr.hhplus.be.server.api.reservation.domain.entity.ReservationOutbox;
+import kr.hhplus.be.server.api.reservation.domain.repository.ReservationOutboxRepository;
+import kr.hhplus.be.server.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import static kr.hhplus.be.server.common.exception.ErrorCode.NOT_FOUND_RESERVATION;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReservationConsumer {
+
+    private final ReservationOutboxRepository outboxRepository;
+
+    @KafkaListener(topics = "sending-reservation-request", groupId = "reservation-group")
+    public void publishRecord(ReservationConfirmedEvent eventPayload) {
+
+        ReservationResult result = eventPayload.reservationResult();
+        long reservationId = result.id();
+
+        ReservationOutbox reservationOutbox = findOutboxById(reservationId);
+        reservationOutbox.published();
+
+        outboxRepository.save(reservationOutbox);
+    }
+
+    private ReservationOutbox findOutboxById(long reservationId) {
+        return outboxRepository.findById(reservationId)
+                .orElseThrow(() -> new CustomException(NOT_FOUND_RESERVATION));
+    }
+
+}

--- a/src/main/java/kr/hhplus/be/server/api/reservation/presentation/consumer/ReservationConsumer.java
+++ b/src/main/java/kr/hhplus/be/server/api/reservation/presentation/consumer/ReservationConsumer.java
@@ -1,39 +1,21 @@
 package kr.hhplus.be.server.api.reservation.presentation.consumer;
 
-import kr.hhplus.be.server.api.reservation.application.dto.ReservationResult;
 import kr.hhplus.be.server.api.reservation.application.event.ReservationConfirmedEvent;
-import kr.hhplus.be.server.api.reservation.domain.entity.ReservationOutbox;
-import kr.hhplus.be.server.api.reservation.domain.repository.ReservationOutboxRepository;
-import kr.hhplus.be.server.common.exception.CustomException;
+import kr.hhplus.be.server.api.reservation.application.service.ReservationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
-
-import static kr.hhplus.be.server.common.exception.ErrorCode.NOT_FOUND_RESERVATION;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class ReservationConsumer {
 
-    private final ReservationOutboxRepository outboxRepository;
+    private final ReservationService reservationService;
 
     @KafkaListener(topics = "sending-reservation-request", groupId = "reservation-group")
     public void publishRecord(ReservationConfirmedEvent eventPayload) {
-
-        ReservationResult result = eventPayload.reservationResult();
-        long reservationId = result.id();
-
-        ReservationOutbox reservationOutbox = findOutboxById(reservationId);
-        reservationOutbox.published();
-
-        outboxRepository.save(reservationOutbox);
+        reservationService.publishRecord(eventPayload);
     }
-
-    private ReservationOutbox findOutboxById(long reservationId) {
-        return outboxRepository.findById(reservationId)
-                .orElseThrow(() -> new CustomException(NOT_FOUND_RESERVATION));
-    }
-
 }

--- a/src/main/java/kr/hhplus/be/server/common/config/JacksonConfig.java
+++ b/src/main/java/kr/hhplus/be/server/common/config/JacksonConfig.java
@@ -1,0 +1,16 @@
+package kr.hhplus.be.server.common.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper()
+                .registerModule(new JavaTimeModule());
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/dataplatform/MockDataPlatformEventConsumer.java
+++ b/src/main/java/kr/hhplus/be/server/dataplatform/MockDataPlatformEventConsumer.java
@@ -1,7 +1,6 @@
 package kr.hhplus.be.server.dataplatform;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import kr.hhplus.be.server.api.reservation.application.dto.ReservationResult;
+import kr.hhplus.be.server.api.reservation.application.event.ReservationConfirmedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -12,14 +11,12 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class MockDataPlatformEventConsumer {
 
-    private final ObjectMapper objectMapper;
     private final MockDataPlatformSendService sendService;
 
     @KafkaListener(topics = "sending-reservation-request", groupId = "reservation-group")
-    public void sendReservationInfo(byte[] eventPayload) {
+    public void sendReservationInfo(ReservationConfirmedEvent event) {
         try {
-            ReservationResult result = objectMapper.readValue(eventPayload, ReservationResult.class);
-            sendService.sendReservationResult(result);
+            sendService.sendReservationResult(event.reservationResult());
         } catch (Exception e) {
             log.error("Error processing Kafka message", e);
         }

--- a/src/main/java/kr/hhplus/be/server/dataplatform/MockDataPlatformEventConsumer.java
+++ b/src/main/java/kr/hhplus/be/server/dataplatform/MockDataPlatformEventConsumer.java
@@ -1,0 +1,27 @@
+package kr.hhplus.be.server.dataplatform;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.hhplus.be.server.api.reservation.application.dto.ReservationResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MockDataPlatformEventConsumer {
+
+    private final ObjectMapper objectMapper;
+    private final MockDataPlatformSendService sendService;
+
+    @KafkaListener(topics = "sending-reservation-request", groupId = "reservation-group")
+    public void sendReservationInfo(byte[] eventPayload) {
+        try {
+            ReservationResult result = objectMapper.readValue(eventPayload, ReservationResult.class);
+            sendService.sendReservationResult(result);
+        } catch (Exception e) {
+            log.error("Error processing Kafka message", e);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
   jpa:
     open-in-view: false
     generate-ddl: false
-    show-sql: true
+    show-sql: false
     hibernate:
       ddl-auto: update
     properties:
@@ -31,7 +31,9 @@ spring:
     username: application
     password: application
   config:
-    import: "classpath:redisson.yml"
+    import:
+      - "classpath:redisson.yml"
+      - "classpath:kafka.yml"
 
 server:
   servlet:

--- a/src/main/resources/kafka.yml
+++ b/src/main/resources/kafka.yml
@@ -1,0 +1,28 @@
+spring:
+  kafka:
+    bootstrap-servers: localhost:9092
+    properties:
+      auto.create.topics.enable: false
+      security.protocol: PLAINTEXT
+      request.timeout.ms: 20000
+      retry.backoff.ms: 500
+      auto:
+        offset.reset: earliest
+        register.schemas: false
+        create.topics.enable: false
+      use.latest.version: true
+      basic.auth.credentials.source: USER_INFO
+    producer:
+      client-id: ${spring.application.name}
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      retries: 5
+    consumer:
+      group-id: ${spring.application.name}
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      properties:
+        enable-auto-commit: false
+    listener:
+      ack-mode: manual

--- a/src/test/java/kr/hhplus/be/server/TestcontainersConfig.java
+++ b/src/test/java/kr/hhplus/be/server/TestcontainersConfig.java
@@ -1,9 +1,9 @@
 package kr.hhplus.be.server;
 
 import com.redis.testcontainers.RedisContainer;
-import jakarta.annotation.PreDestroy;
 import org.springframework.context.annotation.Configuration;
 import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.kafka.ConfluentKafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @Configuration
@@ -11,6 +11,10 @@ class TestcontainersConfig {
 
 	public static final MySQLContainer<?> MYSQL_CONTAINER;
 	public static final RedisContainer REDIS_CONTAINER;
+	public static final ConfluentKafkaContainer KAFKA_CONTAINER = new ConfluentKafkaContainer(
+			DockerImageName.parse("confluentinc/cp-kafka:latest")
+					.asCompatibleSubstituteFor("apache/kafka")
+	);
 
 	static {
 		MYSQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
@@ -29,16 +33,9 @@ class TestcontainersConfig {
 		// Spring Redis 환경 속성 설정
 		System.setProperty("spring.data.redis.host", REDIS_CONTAINER.getHost());
 		System.setProperty("spring.data.redis.port", REDIS_CONTAINER.getMappedPort(6379).toString());
+
+		KAFKA_CONTAINER.start();
+		System.setProperty("spring.kafka.bootstrap-servers", KAFKA_CONTAINER.getBootstrapServers());
 	}
 
-	@PreDestroy
-	public void preDestroy() {
-		if (MYSQL_CONTAINER.isRunning()) {
-			MYSQL_CONTAINER.stop();
-		}
-
-		if (REDIS_CONTAINER.isRunning()) {
-			REDIS_CONTAINER.stop();
-		}
-	}
 }

--- a/src/test/java/kr/hhplus/be/server/api/reservation/integration/KafkaIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/api/reservation/integration/KafkaIntegrationTest.java
@@ -1,0 +1,40 @@
+package kr.hhplus.be.server.api.reservation.integration;
+
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import static org.assertj.core.api.Assertions.assertThat;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import static org.awaitility.Awaitility.await;
+
+
+@SpringBootTest
+public class KafkaIntegrationTest {
+
+    @Autowired
+    private KafkaTemplate<String, String> kafkaTemplate;
+    private static final AtomicInteger counter = new AtomicInteger(0);
+
+
+    @KafkaListener(topics = "reservation-test-topic", groupId = "test-group")
+    public void listen(String message) {
+        counter.incrementAndGet();
+        assertThat(message).isEqualTo("test-message");
+    }
+
+    @DisplayName("Kafka 이벤트 메시지 발행 및 응답 테스트")
+    @Test
+    public void handle_event_test() {
+        kafkaTemplate.send("reservation-test-topic", "test-message");
+        await()
+            .pollInterval(Duration.ofMillis(50))
+            .atMost(Duration.ofSeconds(2))
+            .untilAsserted(() -> {
+                assertThat(counter.get()).isEqualTo(1L);
+            });
+    }
+
+}


### PR DESCRIPTION
### **커밋 링크**

[카프카 학습 내용 정리](https://github.com/ja1ee/hhplus-concert/wiki/(08)-%EC%B9%B4%ED%94%84%EC%B9%B4-%ED%95%99%EC%8A%B5-%EB%82%B4%EC%9A%A9-%EC%A0%95%EB%A6%AC)
[STEP17] 카프카 연동 통합테스트 2fb9b5b
[STEP18] 예약 완료 후 아웃박스 저장 / 재처리 스케줄러 추가 c675ea9 
[fix] 프레젠테이션 레이어의 서비스 로직을 어플리케이션 레이어로 이동 eff9790

---
### **리뷰 포인트(질문)**
- 리뷰 포인트 1
발행 실패한 메시지를 확인하는 스케줄러에서 데이터를 어떻게 조회해오는게 적절할까요?  
가장 오래된 데이터 n개를 조회해서 확인하게 했는데, 시스템의 규모에 따라 n을 계속 바꿔야할테니  부적절한 것 같습니다.  
만약 위 방법대로 하지 않고 outbox false인 건을 전부 조회하고 중복발행 케이스에 대해서는  
consumer에서 멱등성을 보장하는 방법도 고려해볼 수 있을까요?  
현업에서 어떤 방식으로 중복발행 예방하는지 키워드를 알려주심 감사하겠습니다..!


- 리뷰포인트 2
Reservation 테이블 관련, 지난주차 리뷰에 추가 질문 드려도 될까요?
" 확정된 예약을 조회하기 위해 expired_at의 null 여부를 판단하기보다 status를 활용하는건 어땠을까 싶네요. "
이 부분에 대해서 리팩토링하려고 합니다.
초기 설계에서 status 컬럼을 따로 두지 않고 확정된 예약의 expired_at을 null로 변경한 이유는
쿼리 조회할 때 문자열로 상태 비교하고 싶지 않고 컬럼을 늘리고 싶지 않아서 였는데요, 
기능이 늘어날 수록 정책의 직관적인 이해가 어려울 것 같아 수정하려고 합니다.

- 현재 정책
1. 임시 예약 - isReserved = true / expiredAt = 만료시간
2. 예약 완료 - isReserved = true / expiredAt = null
3. 예약 취소 - isReserved = false

reservation 테이블에 status를 추가하고
확정 예약을 관리하는 테이블을 별도로 추가하는 것도 괜찮을까요?

---

